### PR TITLE
Remove target checks from Cargo.toml.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,18 +19,16 @@ itertools = "0.10"
 thiserror = "1.0"
 
 # quick-js is available in unix and x86_64-pc-windows-gnu
-[target.'cfg(any(unix, all(windows, target_env = "gnu")))'.dependencies]
 quick-js = { version = "0.4", features = ["patched"], optional = true }
 
 # duktape is available in unix and windows
-[target.'cfg(any(unix, windows))'.dependencies]
 ducc = { version = "0.1", optional = true }
 
 # wasm-js is available in wasm32-unknown-unknown
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dependencies]
 wasm-bindgen = { version = "0.2", default-features = false, optional = true }
 js-sys = { version = "0.3", optional = true }
-[target.'cfg(all(target_arch = "wasm32", target_os = "unknown"))'.dev-dependencies]
+
+[dev-dependencies]
 wasm-bindgen-test = "0.3"
 
 [features]


### PR DESCRIPTION
This PR removes the conditional compilation flags in Cargo.toml that mention the target platform.

The reason why this was needed is that it is that, though wasm-bindgen and js-sys issue code that panics when compiled to x64, we want to be able to run ``cargo check`` without having to specify the target triple (and both those crates check fine even on x64).

Note that this since these are breaking changes, it would require at least a minor version bump.