### PR TITLE
feat: add quickjs_runtime backend ( xu-cheng/katex-rs#6 )

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,10 @@ thiserror = "1.0"
 [target.'cfg(any(unix, all(windows, target_env = "gnu")))'.dependencies]
 quick-js = { version = "0.4", features = ["patched"], optional = true }
 
+# quickjs_runtime is available in unix
+[target.'cfg(any(unix))'.dependencies]
+quickjs_runtime = { version = "0.12.0", optional = true }
+
 # duktape is available in unix and windows
 [target.'cfg(any(unix, windows))'.dependencies]
 ducc = { version = "0.1", optional = true }
@@ -36,6 +40,7 @@ wasm-bindgen-test = "0.3"
 [features]
 default = ["quick-js"]
 quick-js = ["dep:quick-js"]
+quickjs_runtime = ["dep:quickjs_runtime"]
 duktape = ["dep:ducc"]
 wasm-js = ["dep:wasm-bindgen", "dep:js-sys"]
 wasm-js-test-in-browser = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ quick-js = { version = "0.4", features = ["patched"], optional = true }
 
 # quickjs_runtime is available in unix
 [target.'cfg(any(unix))'.dependencies]
-quickjs_runtime = { version = "0.12.0", optional = true }
+quickjs_runtime = { version = "0.12.1", optional = true }
 
 # duktape is available in unix and windows
 [target.'cfg(any(unix, windows))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,10 +21,7 @@ thiserror = "1.0"
 # quick-js is available in unix and x86_64-pc-windows-gnu
 [target.'cfg(any(unix, all(windows, target_env = "gnu")))'.dependencies]
 quick-js = { version = "0.4", features = ["patched"], optional = true }
-
-# quickjs_runtime is available in unix
-[target.'cfg(any(unix))'.dependencies]
-quickjs_runtime = { version = "0.12.1", optional = true }
+quickjs_runtime = { version = "0.12.1", default-features = false, features = ["console", "setimmediate", "setinterval", "settimeout"], optional = true }
 
 # duktape is available in unix and windows
 [target.'cfg(any(unix, windows))'.dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ thiserror = "1.0"
 # quick-js is available in unix and x86_64-pc-windows-gnu
 [target.'cfg(any(unix, all(windows, target_env = "gnu")))'.dependencies]
 quick-js = { version = "0.4", features = ["patched"], optional = true }
-quickjs_runtime = { version = "0.12.1", default-features = false, features = ["console", "setimmediate", "setinterval", "settimeout"], optional = true }
+quickjs_runtime = { version = "0.13.3", default-features = false, features = ["bellard", "console", "setimmediate", "setinterval", "settimeout"], optional = true }
 
 # duktape is available in unix and windows
 [target.'cfg(any(unix, windows))'.dependencies]

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ katex = "0.4"
 This crate offers the following features:
 
 * `quick-js`: Enable by default. Use [quick-js](https://crates.io/crates/quick-js) as the JS backend.
+* `quickjs_runtime`: Use [quickjs_runtime](https://crates.io/crates/quickjs_runtime) as the JS backend. You need to disable the default features to enable this backend.
 * `duktape`: Use [duktape](https://crates.io/crates/ducc) as the JS backend. You need to disable the default features to enable this backend.
 * `wasm-js`: Use [wasm-bindgen](https://crates.io/crates/wasm-bindgen) and [js-sys](https://crates.io/crates/js-sys) as the JS backend. You need to disable the default features to enable this backend.
 

--- a/src/js_engine.rs
+++ b/src/js_engine.rs
@@ -61,7 +61,7 @@ cfg_if! {
         }
     } else if #[cfg(feature = "quickjs_runtime")] {
         cfg_if! {
-            if #[cfg(any(unix))] {
+            if #[cfg(any(unix, all(windows, target_env = "gnu")))] {
                 mod quickjs_runtime;
 
                 pub(crate) type Engine = self::quickjs_runtime::Engine;

--- a/src/js_engine.rs
+++ b/src/js_engine.rs
@@ -59,6 +59,16 @@ cfg_if! {
                 compile_error!("quick-js backend is not support in the current build target.");
             }
         }
+    } else if #[cfg(feature = "quickjs_runtime")] {
+        cfg_if! {
+            if #[cfg(any(unix))] {
+                mod quickjs_runtime;
+
+                pub(crate) type Engine = self::quickjs_runtime::Engine;
+            } else {
+                compile_error!("quickjs_runtime backend is not support in the current build target.");
+            }
+        }
     } else if #[cfg(feature = "duktape")] {
         cfg_if! {
             if #[cfg(any(unix, windows))] {

--- a/src/js_engine/quickjs_runtime.rs
+++ b/src/js_engine/quickjs_runtime.rs
@@ -75,7 +75,7 @@ pub struct Value(JsValueFacade);
 
 impl<'a> JsValue<'a> for Value {
     fn into_string(self) -> Result<String> {
-        Ok(self.0.stringify())
+        Ok(self.0.get_str().to_string())
     }
 }
 

--- a/src/js_engine/quickjs_runtime.rs
+++ b/src/js_engine/quickjs_runtime.rs
@@ -1,0 +1,89 @@
+//! JS Engine implemented by [quickjs_runtime](https://crates.io/crates/quickjs_runtime).
+
+use std::collections::HashMap;
+
+use quickjs_runtime::{
+    builder::QuickJsRuntimeBuilder,
+    facades::QuickJsRuntimeFacade,
+    jsutils::Script,
+    values::{JsValueConvertable, JsValueFacade},
+};
+
+use crate::{
+    error::{Error, Result},
+    js_engine::{JsEngine, JsValue},
+};
+
+/// quickjs_runtime Engine.
+pub struct Engine(QuickJsRuntimeFacade);
+
+impl JsEngine for Engine {
+    type JsValue<'a> = Value;
+
+    fn new() -> Result<Self> {
+        Ok(Self(QuickJsRuntimeBuilder::new().build()))
+    }
+
+    fn eval<'a>(&'a self, code: &str) -> Result<Self::JsValue<'a>> {
+        self.0
+            .eval_sync(None, Script::new("katex", code))
+            .map(Value)
+            .map_err(|e| Error::JsExecError(format!("{e}")))
+    }
+
+    fn call_function<'a>(
+        &'a self,
+        func_name: &str,
+        args: impl Iterator<Item = Self::JsValue<'a>>,
+    ) -> Result<Self::JsValue<'a>> {
+        self.0
+            .invoke_function_sync(None, &[], func_name, args.map(|v| v.0).collect())
+            .map(Value)
+            .map_err(|e| Error::JsExecError(format!("{e}")))
+    }
+
+    fn create_bool_value(&self, input: bool) -> Result<Self::JsValue<'_>> {
+        Ok(input.into())
+    }
+
+    fn create_int_value(&self, input: i32) -> Result<Self::JsValue<'_>> {
+        Ok(input.into())
+    }
+
+    fn create_float_value(&self, input: f64) -> Result<Self::JsValue<'_>> {
+        Ok(input.into())
+    }
+
+    fn create_string_value(&self, input: String) -> Result<Self::JsValue<'_>> {
+        Ok(input.into())
+    }
+
+    fn create_object_value<'a>(
+        &'a self,
+        input: impl Iterator<Item = (String, Self::JsValue<'a>)>,
+    ) -> Result<Self::JsValue<'a>> {
+        Ok(input
+            .map(|(k, v)| (k, v.0))
+            .collect::<HashMap<_, _>>()
+            .into())
+    }
+}
+
+/// quickjs_runtime Value.
+#[derive(Debug)]
+pub struct Value(JsValueFacade);
+
+impl<'a> JsValue<'a> for Value {
+    fn into_string(self) -> Result<String> {
+        Ok(self.0.stringify())
+    }
+}
+
+impl<T> From<T> for Value
+where
+    T: JsValueConvertable,
+{
+    fn from(value: T) -> Self {
+        Self(value.to_js_value_facade())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@
 //!
 //! * `quick-js`: Enable by default. Use [quick-js](https://crates.io/crates/quick-js)
 //!    as the JS backend.
+//! * `quickjs_runtime`: Use [quickjs_runtime](https://crates.io/crates/quickjs_runtime)
+//!    as the JS backend. You need to disable the default features to enable this backend.
 //! * `duktape`: Use [duktape](https://crates.io/crates/ducc) as the JS backend.
 //!    You need to disable the default features to enable this backend.
 //! * `wasm-js`: Use [wasm-bindgen](https://crates.io/crates/wasm-bindgen) and


### PR DESCRIPTION
This PR adds the `quickjs_runtime` backend, as suggested by [this comment](https://github.com/xu-cheng/katex-rs/issues/6#issuecomment-1379935843).